### PR TITLE
Added use_sudo_password to put_file() call.

### DIFF
--- a/pyinfra_tinc/tinc.py
+++ b/pyinfra_tinc/tinc.py
@@ -201,6 +201,7 @@ def _sync_tinc_config(state, host, netname, tinc_install_prefix, deploy_kwargs):
             sudo=deploy_kwargs.get('sudo'),
             sudo_user=deploy_kwargs.get('sudo_user'),
             su_user=deploy_kwargs.get('su_user'),
+            use_sudo_password=deploy_kwargs.get('use_sudo_password'),
         )
 
 


### PR DESCRIPTION
Now _sync_tinc_config() calls complete successfully when using the use_sudo_password mechanism to pass the sudo password.